### PR TITLE
Update Node to latest LTS since Node SASS dropped Node 9 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.11.2-alpine
+FROM node:10.16.0-alpine
 
 LABEL maintainer="Andreas Peters <support@aventer.biz>"
 #Upstream URL: https://git.aventer.biz/AVENTER/docker-matrix-dimension


### PR DESCRIPTION
Trying to build Docker container ends in failure because Node SASS dropped support for Node 9 in Alpine

This upgrades Node to the latest LTS 10.16 which from my initial testing seems to work fine and doesn't break Dimension.